### PR TITLE
Fix multi-line symbol names

### DIFF
--- a/plugins/KiCadImport.py
+++ b/plugins/KiCadImport.py
@@ -596,8 +596,8 @@ class import_lib:
             return symbol_section, start_index, end_index
 
         def extract_footprint_name(string):
-            pattern = r'\(property "Footprint" "(.*?)"'
-            match = re.search(pattern, string)
+            pattern = r'\(property\s+"Footprint"\s+"(.*?)"'
+            match = re.search(pattern, string, re.MULTILINE)
             if match:
                 original_name = match.group(1)
                 name = self.cleanName(original_name)
@@ -605,6 +605,7 @@ class import_lib:
                     pattern,
                     f'(property "Footprint" "{remote_type.name}:{name}"',
                     string,
+                    flags=re.MULTILINE
                 )
                 return name, modified_string
             else:


### PR DESCRIPTION
Symbols exported by [easyeda2kicad](https://github.com/uPesy/easyeda2kicad.py) have multi-line footprint lines that look like this:

```scheme
(property
  "Footprint"
  "part:SOIC-14_L8.7-W3.9-P1.27-LS6.0-BL"
  (id 2)
  (at 0 -15.24 0)
  (effects (font (size 1.27 1.27) ) hide)
)
```

This commit relaxes the regex to support multi-line matches