### PR TITLE
Bug fixes for Auto Path Creation (for 2024.08.03)

### DIFF
--- a/plugins/impart_action.py
+++ b/plugins/impart_action.py
@@ -70,6 +70,7 @@ class impart_backend:
         self.autoImport = False
         self.overwriteImport = False
         self.import_old_format = False
+        self.autoLib = True
         self.folderhandler = filehandler(".")
         self.print_buffer = ""
         self.importer.print = self.print2buffer
@@ -153,6 +154,7 @@ class impart_frontend(impartGUI):
 
         self.m_autoImport.SetValue(backend_h.autoImport)
         self.m_overwrite.SetValue(backend_h.overwriteImport)
+        self.m_check_autoLib.SetValue(backend_h.autoLib)
         self.m_check_import_all.SetValue(backend_h.import_old_format)
 
         if backend_h.runThread:
@@ -185,6 +187,7 @@ class impart_frontend(impartGUI):
 
         backend_h.autoImport = self.m_autoImport.IsChecked()
         backend_h.overwriteImport = self.m_overwrite.IsChecked()
+        backend_h.autoLib = self.m_check_autoLib.IsChecked()
         backend_h.import_old_format = self.m_check_import_all.IsChecked()
         # backend_h.runThread = False
         self.Thread.stopThread = True  # only for text output
@@ -195,6 +198,7 @@ class impart_frontend(impartGUI):
 
         backend_h.autoImport = self.m_autoImport.IsChecked()
         backend_h.overwriteImport = self.m_overwrite.IsChecked()
+        backend_h.autoLib = self.m_check_autoLib.IsChecked()
         backend_h.import_old_format = self.m_check_import_all.IsChecked()
 
         if backend_h.runThread:

--- a/plugins/impart_helper_func.py
+++ b/plugins/impart_helper_func.py
@@ -209,7 +209,8 @@ class KiCad_Settings:
             if add_if_possible:
                 self.set_lib_table_entry(SearchLib)
                 msg += "\nThe library '" + SearchLib
-                msg += " has been successfully added. A restart of KiCad is necessary."
+                msg += " has been successfully added."
+                msg += "\n##### A restart of KiCad is necessary. #####"
             else:
                 msg += "\nYou have to import the library '" + SearchLib
                 msg += "' with the path '" + temp_path
@@ -230,7 +231,9 @@ class KiCad_Settings:
             if add_if_possible:
                 if SearchLib_name not in SymbolLibs:
                     self.set_sym_table(SearchLib_name, temp_path)
-                    msg += "\nThe library has been successfully added. A restart of KiCad is necessary."
+                    msg += "\nThe library '" + SearchLib
+                    msg += " has been successfully added."
+                    msg += "\n##### A restart of KiCad is necessary. #####"
                 else:
                     msg += "\nThe entry must either be corrected manually or deleted."
                     # self.set_sym_table(SearchLib_name, temp_path) # TODO

--- a/plugins/impart_helper_func.py
+++ b/plugins/impart_helper_func.py
@@ -219,7 +219,7 @@ class KiCad_Settings:
 
     def check_symbollib(self, SearchLib: str, add_if_possible: bool = True):
         msg = ""
-        SearchLib_name = SearchLib.split(".")[0]
+        SearchLib_name = SearchLib.split("_")[0]
 
         SymbolLibs = self.get_sym_table()
         temp_path = "${KICAD_3RD_PARTY}/" + SearchLib


### PR DESCRIPTION
I made it so the auto KiCad setting tick is saved in the backend to fix showing the wrong value when closing and reopening the GUI. It is also set true in the backend to default automatically creating a path. This shouldn't impact users who have already had their paths set. 

I have fixed the naming convention for the symbol lib name path as it appended "_kicad_sym" which it didn't before. 
![image](https://github.com/user-attachments/assets/86cd57e0-e389-4f67-b569-1526925f4969)

Sadly, I can't test out the changes as i am having troubles trying to run the generate_zip.sh on wsl.

I also suggest making it more apparent to the user that they need to close all of KiCad out (not just pcb editor) to make the changes to the path save. (red text in the logs, pointers, etc.)