### PR TITLE
fix version check for nightly

### DIFF
--- a/plugins/impart_action.py
+++ b/plugins/impart_action.py
@@ -74,7 +74,7 @@ class impart_backend:
         self.importer.print = self.print2buffer
 
         def version_to_tuple(version_str):
-            return tuple(map(int, version_str.split(".")))
+            return tuple(map(int, version_str.split('-')[0].split(".")))
 
         minVersion = "8.0.4"
         if version_to_tuple(pcbnew.Version()) < version_to_tuple(minVersion):


### PR DESCRIPTION
Nightly KiCad has version number with `-` suffix (e.g., `9.0.0-rc1-172-g3219e87b3a`), split it and only use the first numeric one to pass version check.