### PR TITLE
feat(gui): integrated component search, smart library auto-discovery, and UX enhancements

### DIFF
--- a/plugins/component_search.py
+++ b/plugins/component_search.py
@@ -453,10 +453,12 @@ class SearchPanel(wx.Panel):  # type: ignore[misc]
         self,
         parent: wx.Window,
         on_select: Callable[[str], None] | None = None,
+        on_import: Callable[[str], None] | None = None,
     ) -> None:
         super().__init__(parent)
         self.api = EasyedaApi()
         self._on_select_cb = on_select
+        self._on_import_cb = on_import
         self._all_results: list[Row] = []
         self._results: list[Row] = []
         self._filter_state = FilterState()
@@ -477,14 +479,19 @@ class SearchPanel(wx.Panel):  # type: ignore[misc]
         root = wx.BoxSizer(wx.VERTICAL)
 
         # ---- search row ----
-        search_row = wx.BoxSizer(wx.HORIZONTAL)
+        search_row = wx.WrapSizer(wx.HORIZONTAL)
         self.search_ctrl = wx.TextCtrl(self, style=wx.TE_PROCESS_ENTER)
         self.search_ctrl.SetHint("Search JLCPCB / EasyEDA …")
+        self.search_ctrl.SetMinSize(wx.Size(160, -1))
         self.btn_search = wx.Button(self, label="Search")
         self.btn_filter = wx.Button(self, label="Filter")
-        search_row.Add(self.search_ctrl, 1, wx.EXPAND | wx.RIGHT, 4)
-        search_row.Add(self.btn_search, 0, wx.RIGHT, 4)
-        search_row.Add(self.btn_filter, 0)
+        self.btn_import = wx.Button(self, label="📥 Import to KiCad")
+        self.btn_import.Disable()
+
+        search_row.Add(self.search_ctrl, 1, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT | wx.BOTTOM, 4)
+        search_row.Add(self.btn_search, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT | wx.BOTTOM, 4)
+        search_row.Add(self.btn_filter, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT | wx.BOTTOM, 4)
+        search_row.Add(self.btn_import, 0, wx.ALIGN_CENTER_VERTICAL | wx.BOTTOM, 4)
         root.Add(search_row, 0, wx.EXPAND | wx.ALL, 6)
 
         # ---- splitter: result list (top) / detail panel (bottom) ----
@@ -514,7 +521,10 @@ class SearchPanel(wx.Panel):  # type: ignore[misc]
         self.btn_search.Bind(wx.EVT_BUTTON, self._on_search)
         self.search_ctrl.Bind(wx.EVT_TEXT_ENTER, self._on_search)
         self.btn_filter.Bind(wx.EVT_BUTTON, self._on_filter)
+        self.btn_import.Bind(wx.EVT_BUTTON, self._on_import_clicked)
         self.list_ctrl.Bind(wx.EVT_LIST_ITEM_SELECTED, self._on_item_selected)
+        self.list_ctrl.Bind(wx.EVT_LIST_ITEM_DESELECTED, self._on_item_deselected)
+        self.list_ctrl.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self._on_item_activated)
         self.list_ctrl.Bind(wx.EVT_LIST_COL_CLICK, self._on_col_click)
 
     # ------------------------------------------------------------------
@@ -631,6 +641,8 @@ class SearchPanel(wx.Panel):  # type: ignore[misc]
             lcsc_url = row.get("url", "")
             lcsc = _pick(row, ["lcsc", "componentCode"])
 
+            self.btn_import.Enable(bool(lcsc))
+
             self._image_request_id += 1
             threading.Thread(
                 target=self._fetch_image, args=(str(lcsc_url), self._image_request_id), daemon=True
@@ -643,6 +655,24 @@ class SearchPanel(wx.Panel):  # type: ignore[misc]
 
             if self._on_select_cb is not None and lcsc:
                 self._on_select_cb(lcsc)
+
+    def _on_item_deselected(self, event: wx.ListEvent) -> None:
+        if self.list_ctrl.GetSelectedItemCount() == 0:
+            self.btn_import.Disable()
+            self.detail_panel.clear()
+
+    def _on_item_activated(self, event: wx.ListEvent) -> None:
+        idx = event.GetIndex()
+        if 0 <= idx < len(self._results):
+            row = self._results[idx]
+            lcsc = _pick(row, ["lcsc", "componentCode"])
+            if lcsc and self._on_import_cb is not None:
+                self._on_import_cb(lcsc)
+
+    def _on_import_clicked(self, event: wx.CommandEvent) -> None:
+        lcsc = self.get_selected_lcsc()
+        if lcsc and self._on_import_cb is not None:
+            self._on_import_cb(lcsc)
 
     def _fetch_image(self, lcsc_url: str, req_id: int) -> None:
         if lcsc_url in self._image_cache:
@@ -749,19 +779,22 @@ class SearchDialog(wx.Dialog):  # type: ignore[misc]
     on_select:
         Optional callback called immediately whenever the user clicks a row in
         the result list.  Receives the LCSC# string of the selected component.
+    on_import:
+        Optional callback called when the user double-clicks or clicks Import.
     """
 
     def __init__(
         self,
         parent: wx.Window,
         on_select: Callable[[str], None] | None = None,
+        on_import: Callable[[str], None] | None = None,
     ) -> None:
         super().__init__(
             parent,
             title="Component Search",
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
         )
-        self.panel = SearchPanel(self, on_select=on_select)
+        self.panel = SearchPanel(self, on_select=on_select, on_import=on_import)
 
         root = wx.BoxSizer(wx.VERTICAL)
         root.Add(self.panel, 1, wx.EXPAND)

--- a/plugins/impart_action.py
+++ b/plugins/impart_action.py
@@ -1066,9 +1066,10 @@ class ImpartFrontend(impartGUI):
             path_variable = "${KICAD_3RD_PARTY}"
             base_folder = Path(self.backend.config.get_DEST_PATH())
 
+        target_lib_name = self.backend.importer.lib_name or "EasyEDA"
         config = ImportConfig(
             base_folder=Path(base_folder),
-            lib_name=self.backend.importer.lib_name or "EasyEDA",
+            lib_name=target_lib_name,
             overwrite=self.m_overwrite.IsChecked(),
             lib_var=path_variable,
             compress_models=self.m_checkBoxCompressModels.IsChecked(),

--- a/plugins/impart_action.py
+++ b/plugins/impart_action.py
@@ -433,7 +433,6 @@ class ImpartFrontend(impartGUI):
         self.m_checkBoxSingleLib.SetValue(single_lib)
         self.m_textCtrl_libname.SetValue(lib_name)
         self.m_textCtrl_libname.Show(single_lib)
-        self.Layout()
         self.backend.importer.lib_name = lib_name if single_lib and lib_name else None
 
         compress_models_val = self.backend.config.get_value("compress_models")
@@ -441,10 +440,45 @@ class ImpartFrontend(impartGUI):
         self.m_checkBoxCompressModels.SetValue(compress_models)
         self.backend.compress_models = compress_models
 
+        # Embed Component Search Panel on the right side
+        try:
+            from .component_search import SearchPanel
+        except ImportError:
+            from component_search import SearchPanel  # type: ignore[import-not-found,no-redef]
+
+        self.search_panel = SearchPanel(
+            self.rightPanel,
+            on_select=self._on_search_component_selected,
+            on_import=self._on_search_component_import,
+        )
+        self.rightSizer.Add(self.search_panel, 1, wx.EXPAND)
+
+        # Read saved search panel visibility from config (default: False)
+        show_search_panel_cfg = self.backend.config.get_value("show_search_panel")
+        self.search_panel_visible = show_search_panel_cfg == "True"
+        self._update_search_panel_visibility(initial=True)
+
         self._update_button_label()
         # Add drag & drop support
         self._setup_drag_drop()
         self._add_drag_drop_hint()
+
+        # Perform comprehensive layout update
+        self.leftPanel.Layout()
+        self.rightPanel.Layout()
+        self.splitter.UpdateSize()
+        self.Layout()
+        wx.CallAfter(self._initial_layout_refresh)
+
+    def _initial_layout_refresh(self) -> None:
+        """Ensure all nested sizers and controls are refreshed after initial window display."""
+        try:
+            self.leftPanel.Layout()
+            self.rightPanel.Layout()
+            self.splitter.UpdateSize()
+            self.Layout()
+        except Exception:
+            pass
 
     def _setup_events(self) -> None:
         """Setup event handlers."""
@@ -553,6 +587,7 @@ class ImpartFrontend(impartGUI):
         """Handle single library name checkbox change."""
         enabled = self.m_checkBoxSingleLib.IsChecked()
         self.m_textCtrl_libname.Show(enabled)
+        self.leftPanel.Layout()
         self.Layout()
         if enabled:
             name = self.m_textCtrl_libname.GetValue().strip()
@@ -789,20 +824,69 @@ class ImpartFrontend(impartGUI):
 
         event.Skip()
 
-    def OnComponentSearch(self, event: wx.CommandEvent) -> None:
-        """Open the component search dialog and fill the LCSC field on selection."""
+    def _on_search_component_selected(self, lcsc: str) -> None:
+        """Update LCSC input field when a component is clicked in the search panel."""
+        self.m_textCtrl2.SetValue(lcsc)
+
+    def _on_search_component_import(self, lcsc: str) -> None:
+        """Trigger immediate 1-click import for the selected component."""
+        self.m_textCtrl2.SetValue(lcsc)
+        self._update_backend_settings()
         try:
-            from .component_search import SearchDialog
-        except ImportError:
-            from component_search import SearchDialog  # type: ignore[import-not-found,no-redef]
+            self.backend.print_to_buffer(f"\n[1-Click Import] Starting import for {lcsc}...")
+            self._perform_easyeda_import()
+        except Exception as e:
+            error_msg = f"Error: {e}\nPython version: {sys.version}"
+            self.backend.print_to_buffer(error_msg)
+            logging.exception(f"1-click import failed for {lcsc}")
+        self._check_and_show_library_warnings()
 
-        def _live_update(lcsc: str) -> None:
-            self.m_textCtrl2.SetValue(lcsc)
+    def _update_search_panel_visibility(self, initial: bool = False) -> None:
+        """Toggle or set the visibility of the search panel in the splitter."""
+        if self.search_panel_visible:
+            if not self.splitter.IsSplit():
+                self.splitter.SplitVertically(self.leftPanel, self.rightPanel, sashPosition=520)
+            self.m_buttonToggleSearch.SetLabel("🔍 Search ◀")
+            self.m_buttonToggleSearch.SetToolTip("Hide component search panel")
+            current_w, current_h = self.GetSize().Get()
+            if current_w < 1100:
+                self.SetSize(wx.Size(1200, max(current_h, 700)))
+        else:
+            if self.splitter.IsSplit():
+                self.splitter.Unsplit(self.rightPanel)
+            self.m_buttonToggleSearch.SetLabel("🔍 Search ▶")
+            self.m_buttonToggleSearch.SetToolTip("Show component search panel")
+            current_w, current_h = self.GetSize().Get()
+            if current_w > 800:
+                self.SetSize(wx.Size(650, max(current_h, 680)))
 
-        dlg = SearchDialog(self, on_select=_live_update)
-        dlg.ShowModal()
-        dlg.Destroy()
+        self.leftPanel.Layout()
+        self.rightPanel.Layout()
+        self.splitter.UpdateSize()
+        self.Layout()
+        if not initial:
+            self.Centre(wx.BOTH)
+
+    def OnToggleSearchPanel(self, event: wx.CommandEvent) -> None:
+        """Toggle the visibility of the right search panel and save preference."""
+        self.search_panel_visible = not self.search_panel_visible
+        self.backend.config.set_value("show_search_panel", str(self.search_panel_visible))
+        self._update_search_panel_visibility()
+        if (
+            self.search_panel_visible
+            and hasattr(self, "search_panel")
+            and hasattr(self.search_panel, "search_ctrl")
+        ):
+            self.search_panel.search_ctrl.SetFocus()
         event.Skip()
+
+    def OnComponentSearch(self, event: wx.CommandEvent) -> None:
+        """Toggle or focus search panel when search event is triggered."""
+        if not self.search_panel_visible:
+            self.OnToggleSearchPanel(event)
+        elif hasattr(self, "search_panel") and hasattr(self.search_panel, "search_ctrl"):
+            self.search_panel.search_ctrl.SetFocus()
+            event.Skip()
 
     def ButtomManualImport(self, event: wx.CommandEvent) -> None:
         """Handle manual EasyEDA import."""

--- a/plugins/impart_action.py
+++ b/plugins/impart_action.py
@@ -433,7 +433,9 @@ class ImpartFrontend(impartGUI):
         self.m_checkBoxSingleLib.SetValue(single_lib)
         self.m_textCtrl_libname.SetValue(lib_name)
         self.m_textCtrl_libname.Show(single_lib)
+        self.m_buttonLibSelect.Show(single_lib)
         self.backend.importer.lib_name = lib_name if single_lib and lib_name else None
+        self._update_library_discovery_ui(auto_set_default=not bool(lib_name))
 
         compress_models_val = self.backend.config.get_value("compress_models")
         compress_models = compress_models_val == "True"  # default False if not set
@@ -580,6 +582,7 @@ class ImpartFrontend(impartGUI):
         # Print change information
         if old_local_lib != self.backend.local_lib:
             self._print_path_change("library_mode")
+            self._update_library_discovery_ui(auto_set_default=True)
 
         event.Skip()
 
@@ -587,13 +590,15 @@ class ImpartFrontend(impartGUI):
         """Handle single library name checkbox change."""
         enabled = self.m_checkBoxSingleLib.IsChecked()
         self.m_textCtrl_libname.Show(enabled)
-        self.leftPanel.Layout()
-        self.Layout()
+        self.m_buttonLibSelect.Show(enabled)
         if enabled:
+            self._update_library_discovery_ui(auto_set_default=True)
             name = self.m_textCtrl_libname.GetValue().strip()
             self.backend.importer.lib_name = name if name else None
         else:
             self.backend.importer.lib_name = None
+        self.leftPanel.Layout()
+        self.Layout()
         event.Skip()
 
     def on_close(self, event: wx.CloseEvent) -> None:
@@ -821,7 +826,108 @@ class ImpartFrontend(impartGUI):
             self._print_path_change("source", new_src)
         if old_dest != new_dest:
             self._print_path_change("destination", new_dest)
+            self._update_library_discovery_ui(auto_set_default=False)
 
+        event.Skip()
+
+    def _scan_target_libraries(self) -> list[str]:
+        """Scan active target directory (project root or global DEST_PATH) for libraries."""
+        if self.backend.local_lib and self.kicad_project:
+            target_dir = Path(self.kicad_project)
+        else:
+            dest = self.backend.config.get_DEST_PATH()
+            target_dir = Path(dest) if dest else None
+
+        if not target_dir or not target_dir.exists() or not target_dir.is_dir():
+            return []
+
+        discovered: set[str] = set()
+        try:
+            for item in target_dir.glob("*.kicad_sym"):
+                if item.is_file() and not item.name.startswith("."):
+                    discovered.add(item.stem)
+
+            for item in target_dir.glob("*.pretty"):
+                if item.is_dir() and not item.name.startswith("."):
+                    discovered.add(item.stem)
+        except Exception as e:
+            logging.debug(f"Error scanning libraries in {target_dir}: {e}")
+
+        return sorted(list(discovered))
+
+    def _update_library_discovery_ui(self, auto_set_default: bool = False) -> None:
+        """Update library count badge and suggest smart default library name."""
+        discovered = self._scan_target_libraries()
+        count = len(discovered)
+
+        if hasattr(self, "m_buttonLibSelect"):
+            self.m_buttonLibSelect.SetLabel(f"📚 ({count})")
+            target_name = (
+                "project folder"
+                if (self.backend.local_lib and self.kicad_project)
+                else "global library folder"
+            )
+            self.m_buttonLibSelect.SetToolTip(
+                f"Found {count} library/libraries in {target_name}.\nClick to pick one."
+            )
+
+        # Smart defaulting when single lib mode is active
+        if auto_set_default and hasattr(self, "m_textCtrl_libname"):
+            current_val = self.m_textCtrl_libname.GetValue().strip()
+
+            if self.backend.local_lib and self.kicad_project:
+                proj_name = Path(self.kicad_project).name
+                if count == 1:
+                    # Exactly one existing project library -> select it
+                    self.m_textCtrl_libname.SetValue(discovered[0])
+                elif not current_val or current_val not in discovered:
+                    # No libraries or old stale name -> suggest project name
+                    self.m_textCtrl_libname.SetValue(proj_name)
+            elif not self.backend.local_lib:
+                if not current_val and count > 0:
+                    self.m_textCtrl_libname.SetValue(discovered[0])
+
+    def _set_lib_name(self, name: str) -> None:
+        """Set the library name from dropdown selection and save settings."""
+        self.m_textCtrl_libname.SetValue(name)
+        self._update_backend_settings()
+        self.backend.print_to_buffer(f"Selected target library: '{name}'")
+
+    def OnSelectDiscoveredLib(self, event: wx.CommandEvent) -> None:
+        """Show a popup menu listing all detected libraries in the current target path."""
+        discovered = self._scan_target_libraries()
+        menu = wx.Menu()
+
+        if discovered:
+            for lib_name in discovered:
+                item = menu.Append(wx.ID_ANY, f"📚 {lib_name}")
+                self.Bind(
+                    wx.EVT_MENU,
+                    lambda _, name=lib_name: self._set_lib_name(name),
+                    item,
+                )
+
+            menu.AppendSeparator()
+            if self.backend.local_lib and self.kicad_project:
+                proj_name = Path(self.kicad_project).name
+                item_proj = menu.Append(wx.ID_ANY, f"✨ Use project name ({proj_name})")
+                self.Bind(wx.EVT_MENU, lambda _: self._set_lib_name(proj_name), item_proj)
+        else:
+            item_none = menu.Append(wx.ID_ANY, "(No existing libraries found)")
+            item_none.Enable(False)
+
+            if self.backend.local_lib and self.kicad_project:
+                menu.AppendSeparator()
+                proj_name = Path(self.kicad_project).name
+                item_proj = menu.Append(
+                    wx.ID_ANY, f"✨ Set as project name ({proj_name})"
+                )
+                self.Bind(wx.EVT_MENU, lambda _: self._set_lib_name(proj_name), item_proj)
+
+        pos = self.m_buttonLibSelect.GetPosition()
+        size = self.m_buttonLibSelect.GetSize()
+        self.leftPanel.PopupMenu(menu, wx.Point(pos.x, pos.y + size.height))
+        menu.Destroy()
         event.Skip()
 
     def _on_search_component_selected(self, lcsc: str) -> None:

--- a/plugins/impart_easyeda.py
+++ b/plugins/impart_easyeda.py
@@ -101,14 +101,16 @@ class EasyEDAImporter:
                 footprint_lib_name=self.config.lib_name,
                 overwrite=self.config.overwrite,
             ):
-                self._print(f"Symbol '{component_name}' already exists.")
+                self._print(
+                    f"Notice: Symbol '{component_name}' already exists in '{self.config.lib_name}.kicad_sym'. (Check 'overwrite lib' to replace)"
+                )
                 return False, component_name
 
             if easyeda_symbol.sub_symbols:
                 self._print(
                     f"Imported {len(easyeda_symbol.sub_symbols)} sub-symbols for: {component_name}"
                 )
-            self._print(f"Saved symbol: {component_name}")
+            self._print(f"Saved symbol: {component_name} -> {self.config.lib_name}.kicad_sym")
             return True, component_name
 
         except Exception as e:
@@ -122,7 +124,9 @@ class EasyEDAImporter:
             footprint_file = self.footprint_dir / f"{ee_footprint.info.name}.kicad_mod"
 
             if footprint_file.exists() and not self.config.overwrite:
-                self._print(f"Footprint already exists: {footprint_file.name}")
+                self._print(
+                    f"Notice: Footprint '{footprint_file.name}' already exists in '{self.config.lib_name}.pretty/'. (Check 'overwrite lib' to replace)"
+                )
                 return None
 
             model_3d_path = f"{self.config.lib_var}/{self.config.lib_name}.3dshapes"
@@ -131,7 +135,7 @@ class EasyEDAImporter:
                 model_3d_path=model_3d_path,
                 model_3d_extension=model_ext,
             )
-            self._print(f"Created footprint: {footprint_file.name}")
+            self._print(f"Created footprint: {footprint_file.name} -> {self.config.lib_name}.pretty/")
             return footprint_file
 
         except Exception as e:
@@ -167,12 +171,12 @@ class EasyEDAImporter:
             if not self.config.overwrite and self.config.compress_models:
                 step_gz = self.model_dir / f"{model_name}.step.gz"
                 if step_gz.exists():
-                    self._print("3D model files already exist.")
+                    self._print(f"Notice: 3D model '{model_name}.step.gz' already exists in '{self.config.lib_name}.3dshapes/'.")
                     wrl_path = self.model_dir / f"{model_name}.wrl"
                     return wrl_path if wrl_path.exists() else None, step_gz
 
             if not exporter.export(output_dir=str(self.model_dir), overwrite=self.config.overwrite):
-                self._print("3D model files already exist.")
+                self._print(f"Notice: 3D model '{model_name}' already exists in '{self.config.lib_name}.3dshapes/'.")
                 return None, None
 
             wrl_path = self.model_dir / f"{model_name}.wrl"
@@ -192,9 +196,9 @@ class EasyEDAImporter:
                 step = gz_path
 
             if wrl:
-                self._print(f"Created 3D model (WRL): {wrl.name}")
+                self._print(f"Created 3D model (WRL): {wrl.name} -> {self.config.lib_name}.3dshapes/")
             if step:
-                self._print(f"Created 3D model (STEP): {step.name}")
+                self._print(f"Created 3D model (STEP): {step.name} -> {self.config.lib_name}.3dshapes/")
 
             return wrl, step
 
@@ -208,7 +212,8 @@ class EasyEDAImporter:
         Import a component and all its assets.
         Returns ImportPaths with all created file paths.
         """
-        self._print(f"Starting import for EasyEDA/LCSC component: {component_id}")
+        self._print(f"Starting import for component: {component_id}")
+        self._print(f"Target library: '{self.config.lib_name}' in {self.config.base_folder}")
 
         if not component_id.startswith("C"):
             error_msg = (
@@ -248,15 +253,17 @@ class EasyEDAImporter:
             created_files = sum(1 for path in result if path)
             if created_files > 0:
                 self._print(
-                    f"EasyEDA import completed successfully! ({created_files} files created)"
+                    f"✓ Import completed successfully for {component_id} into '{self.config.lib_name}'! ({created_files} files created)"
                 )
             else:
-                self._print("EasyEDA import completed, but no new files were created")
+                self._print(
+                    f"Import completed for {component_id}, but no new files were created in '{self.config.lib_name}' (already existed)."
+                )
 
             return result
 
         except Exception as e:
-            self._print(f"EasyEDA import failed: {e}")
+            self._print(f"Import failed for {component_id}: {e}")
             logger.error(f"Component import failed for {component_id}: {e}")
             raise
 

--- a/plugins/impart_gui.py
+++ b/plugins/impart_gui.py
@@ -110,37 +110,65 @@ class impartGUI(wx.Dialog):
         self.m_autoImport = wx.CheckBox(
             self.leftPanel, wx.ID_ANY, "auto import", wx.DefaultPosition, wx.DefaultSize, 0
         )
+        self.m_autoImport.SetToolTip(
+            "Automatically monitors the download folder and imports new library archives in real-time."
+        )
         fgSizer1.Add(self.m_autoImport, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 4)
 
         self.m_check_autoLib = wx.CheckBox(
             self.leftPanel, wx.ID_ANY, "auto settings", wx.DefaultPosition, wx.DefaultSize, 0
+        )
+        self.m_check_autoLib.SetToolTip(
+            "Automatically registers imported symbol and footprint libraries into KiCad's library tables."
         )
         fgSizer1.Add(self.m_check_autoLib, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 4)
 
         self.m_overwrite = wx.CheckBox(
             self.leftPanel, wx.ID_ANY, "overwrite lib", wx.DefaultPosition, wx.DefaultSize, 0
         )
+        self.m_overwrite.SetToolTip(
+            "Overwrites existing symbols, footprints, and 3D models if they already exist in the target library."
+        )
         fgSizer1.Add(self.m_overwrite, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 4)
 
         self.m_checkBoxCompressModels = wx.CheckBox(
             self.leftPanel, wx.ID_ANY, "zip 3D", wx.DefaultPosition, wx.DefaultSize, 0
         )
+        self.m_checkBoxCompressModels.SetToolTip(
+            "Compresses 3D STEP models to .step.gz to save disk space and improve load performance."
+        )
         fgSizer1.Add(self.m_checkBoxCompressModels, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 4)
 
-        # Single lib checkbox and text field grouped together so they wrap as a single unit
+        # Single lib checkbox, text field and discovery button grouped together
         single_lib_sizer = wx.BoxSizer(wx.HORIZONTAL)
         self.m_checkBoxSingleLib = wx.CheckBox(
             self.leftPanel, wx.ID_ANY, "single lib name", wx.DefaultPosition, wx.DefaultSize, 0
+        )
+        self.m_checkBoxSingleLib.SetToolTip(
+            "Merges all imported components into a single unified library instead of separate source files."
         )
         single_lib_sizer.Add(self.m_checkBoxSingleLib, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 4)
 
         self.m_textCtrl_libname = wx.TextCtrl(
             self.leftPanel, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0
         )
-        self.m_textCtrl_libname.SetMinSize(wx.Size(130, -1))
+        self.m_textCtrl_libname.SetMinSize(wx.Size(120, -1))
         self.m_textCtrl_libname.SetHint("e.g. MyLibrary")
+        self.m_textCtrl_libname.SetToolTip(
+            "Target library name (without extension). E.g. 'ProjectLib' or 'Custom'."
+        )
         self.m_textCtrl_libname.Show(False)
         single_lib_sizer.Add(self.m_textCtrl_libname, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 2)
+
+        self.m_buttonLibSelect = wx.Button(
+            self.leftPanel, wx.ID_ANY, "📚 (0)", wx.DefaultPosition, wx.DefaultSize, 0
+        )
+        self.m_buttonLibSelect.SetMinSize(wx.Size(65, -1))
+        self.m_buttonLibSelect.SetToolTip(
+            "Click to pick from detected libraries in the active target location."
+        )
+        self.m_buttonLibSelect.Show(False)
+        single_lib_sizer.Add(self.m_buttonLibSelect, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 3)
 
         fgSizer1.Add(single_lib_sizer, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 4)
 
@@ -167,6 +195,7 @@ class impartGUI(wx.Dialog):
             wx.DefaultSize,
             wx.DIRP_DEFAULT_STYLE,
         )
+        self.m_dirPicker_sourcepath.SetToolTip("Folder containing downloaded component ZIP archives to import.")
         bSizer.Add(self.m_dirPicker_sourcepath, 0, wx.ALL | wx.EXPAND, 5)
 
         bSizer2 = wx.WrapSizer(wx.HORIZONTAL)
@@ -191,6 +220,9 @@ class impartGUI(wx.Dialog):
             wx.DefaultSize,
             0,
         )
+        self.m_checkBoxLocalLib.SetToolTip(
+            "Saves libraries inside the current KiCad project folder (${KIPRJMOD}) instead of the global library path."
+        )
         bSizer2.Add(self.m_checkBoxLocalLib, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
 
         bSizer.Add(bSizer2, 0, wx.EXPAND, 0)
@@ -203,6 +235,9 @@ class impartGUI(wx.Dialog):
             wx.DefaultPosition,
             wx.DefaultSize,
             wx.DIRP_DEFAULT_STYLE,
+        )
+        self.m_dirPicker_librarypath.SetToolTip(
+            "Global destination folder for storing KiCad libraries (${KICAD_3RD_PARTY})."
         )
         bSizer.Add(self.m_dirPicker_librarypath, 0, wx.ALL | wx.EXPAND, 5)
 
@@ -248,6 +283,7 @@ class impartGUI(wx.Dialog):
         self.m_buttonImportManual.Bind(wx.EVT_BUTTON, self.ButtomManualImport)
         self.m_textCtrl2.Bind(wx.EVT_TEXT_ENTER, self.ButtomManualImport)
         self.m_buttonToggleSearch.Bind(wx.EVT_BUTTON, self.OnToggleSearchPanel)
+        self.m_buttonLibSelect.Bind(wx.EVT_BUTTON, self.OnSelectDiscoveredLib)
         self.m_dirPicker_sourcepath.Bind(wx.EVT_DIRPICKER_CHANGED, self.DirChange)
         self.m_checkBoxLocalLib.Bind(wx.EVT_CHECKBOX, self.m_checkBoxLocalLibOnCheckBox)
         self.m_checkBoxSingleLib.Bind(wx.EVT_CHECKBOX, self.m_checkBoxSingleLibOnCheckBox)
@@ -267,6 +303,9 @@ class impartGUI(wx.Dialog):
         event.Skip()
 
     def OnToggleSearchPanel(self, event):
+        event.Skip()
+
+    def OnSelectDiscoveredLib(self, event):
         event.Skip()
 
     def DirChange(self, event):

--- a/plugins/impart_gui.py
+++ b/plugins/impart_gui.py
@@ -21,20 +21,31 @@ class impartGUI(wx.Dialog):
             id=wx.ID_ANY,
             title="impartGUI",
             pos=wx.DefaultPosition,
-            size=wx.Size(650, 650),
+            size=wx.Size(1200, 700),
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.BORDER_DEFAULT,
         )
 
-        self.SetSizeHints(wx.DefaultSize, wx.DefaultSize)
+        self.SetSizeHints(wx.Size(500, 500), wx.DefaultSize)
         self.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW))
 
+        dialogSizer = wx.BoxSizer(wx.VERTICAL)
+
+        # ----------------- Splitter Window (Resizable Panels) -----------------
+        self.splitter = wx.SplitterWindow(
+            self,
+            style=wx.SP_LIVE_UPDATE | wx.SP_3DSASH | wx.SP_NO_XP_THEME,
+        )
+        self.splitter.SetMinimumPaneSize(350)
+
+        # ----------------- Left Panel (Main / Import) -----------------
+        self.leftPanel = wx.Panel(self.splitter)
         bSizer = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_button = wx.Button(self, wx.ID_ANY, "Start", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.m_button = wx.Button(self.leftPanel, wx.ID_ANY, "Start", wx.DefaultPosition, wx.DefaultSize, 0)
         bSizer.Add(self.m_button, 0, wx.ALL | wx.EXPAND, 5)
 
         self.m_text = wx.TextCtrl(
-            self,
+            self.leftPanel,
             wx.ID_ANY,
             wx.EmptyString,
             wx.DefaultPosition,
@@ -44,7 +55,7 @@ class impartGUI(wx.Dialog):
         bSizer.Add(self.m_text, 1, wx.ALL | wx.EXPAND, 5)
 
         self.m_staticline11 = wx.StaticLine(
-            self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL
+            self.leftPanel, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL
         )
         self.m_staticline11.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW))
         self.m_staticline11.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
@@ -58,80 +69,85 @@ class impartGUI(wx.Dialog):
         fgSizer2.AddGrowableCol(1)
 
         self.m_staticTextLCSC = wx.StaticText(
-            self, wx.ID_ANY, "EasyEDA / LCSC Part#", wx.DefaultPosition, wx.DefaultSize, 0
+            self.leftPanel, wx.ID_ANY, "EasyEDA / LCSC Part#", wx.DefaultPosition, wx.DefaultSize, 0
         )
         fgSizer2.Add(self.m_staticTextLCSC, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
 
         self.m_textCtrl2 = wx.TextCtrl(
-            self,
+            self.leftPanel,
             wx.ID_ANY,
             wx.EmptyString,
             wx.DefaultPosition,
             wx.DefaultSize,
             wx.TE_PROCESS_ENTER,
         )
-        self.m_textCtrl2.SetMinSize(wx.Size(220, -1))
+        self.m_textCtrl2.SetMinSize(wx.Size(120, -1))
         fgSizer2.Add(self.m_textCtrl2, 1, wx.EXPAND | wx.ALL, 5)
 
         self.m_buttonImportManual = wx.Button(
-            self, wx.ID_ANY, "Import", wx.DefaultPosition, wx.DefaultSize, 0
+            self.leftPanel, wx.ID_ANY, "Import", wx.DefaultPosition, wx.DefaultSize, 0
         )
         fgSizer2.Add(self.m_buttonImportManual, 0, wx.ALL, 5)
 
-        self.m_buttonComponentSearch = wx.Button(
-            self, wx.ID_ANY, "Component Search", wx.DefaultPosition, wx.DefaultSize, 0
+        self.m_buttonToggleSearch = wx.Button(
+            self.leftPanel, wx.ID_ANY, "🔍 Search ▶", wx.DefaultPosition, wx.DefaultSize, 0
         )
-        fgSizer2.Add(self.m_buttonComponentSearch, 0, wx.ALL, 5)
+        fgSizer2.Add(self.m_buttonToggleSearch, 0, wx.ALL, 5)
 
         bSizer.Add(fgSizer2, 0, wx.EXPAND | wx.ALL, 0)
 
         self.m_staticline12 = wx.StaticLine(
-            self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL
+            self.leftPanel, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL
         )
         self.m_staticline12.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW))
         self.m_staticline12.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
 
         bSizer.Add(self.m_staticline12, 0, wx.EXPAND | wx.ALL, 5)
 
-        fgSizer1 = wx.BoxSizer(wx.HORIZONTAL)
+        # Use WrapSizer for responsive auto-wrapping checkboxes
+        fgSizer1 = wx.WrapSizer(wx.HORIZONTAL)
 
         self.m_autoImport = wx.CheckBox(
-            self, wx.ID_ANY, "auto import", wx.DefaultPosition, wx.DefaultSize, 0
+            self.leftPanel, wx.ID_ANY, "auto import", wx.DefaultPosition, wx.DefaultSize, 0
         )
-        fgSizer1.Add(self.m_autoImport, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        fgSizer1.Add(self.m_autoImport, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 4)
 
         self.m_check_autoLib = wx.CheckBox(
-            self, wx.ID_ANY, "auto settings", wx.DefaultPosition, wx.DefaultSize, 0
+            self.leftPanel, wx.ID_ANY, "auto settings", wx.DefaultPosition, wx.DefaultSize, 0
         )
-        fgSizer1.Add(self.m_check_autoLib, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        fgSizer1.Add(self.m_check_autoLib, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 4)
 
         self.m_overwrite = wx.CheckBox(
-            self, wx.ID_ANY, "overwrite lib", wx.DefaultPosition, wx.DefaultSize, 0
+            self.leftPanel, wx.ID_ANY, "overwrite lib", wx.DefaultPosition, wx.DefaultSize, 0
         )
-        fgSizer1.Add(self.m_overwrite, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        fgSizer1.Add(self.m_overwrite, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 4)
 
         self.m_checkBoxCompressModels = wx.CheckBox(
-            self, wx.ID_ANY, "zip 3D", wx.DefaultPosition, wx.DefaultSize, 0
+            self.leftPanel, wx.ID_ANY, "zip 3D", wx.DefaultPosition, wx.DefaultSize, 0
         )
-        fgSizer1.Add(self.m_checkBoxCompressModels, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        fgSizer1.Add(self.m_checkBoxCompressModels, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 4)
 
+        # Single lib checkbox and text field grouped together so they wrap as a single unit
+        single_lib_sizer = wx.BoxSizer(wx.HORIZONTAL)
         self.m_checkBoxSingleLib = wx.CheckBox(
-            self, wx.ID_ANY, "single lib name", wx.DefaultPosition, wx.DefaultSize, 0
+            self.leftPanel, wx.ID_ANY, "single lib name", wx.DefaultPosition, wx.DefaultSize, 0
         )
-        fgSizer1.Add(self.m_checkBoxSingleLib, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        single_lib_sizer.Add(self.m_checkBoxSingleLib, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 4)
 
         self.m_textCtrl_libname = wx.TextCtrl(
-            self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0
+            self.leftPanel, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0
         )
-        self.m_textCtrl_libname.SetMinSize(wx.Size(150, -1))
+        self.m_textCtrl_libname.SetMinSize(wx.Size(130, -1))
         self.m_textCtrl_libname.SetHint("e.g. MyLibrary")
         self.m_textCtrl_libname.Show(False)
-        fgSizer1.Add(self.m_textCtrl_libname, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        single_lib_sizer.Add(self.m_textCtrl_libname, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 2)
 
-        bSizer.Add(fgSizer1, 0, wx.ALIGN_CENTER, 5)
+        fgSizer1.Add(single_lib_sizer, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 4)
+
+        bSizer.Add(fgSizer1, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 4)
 
         self.m_staticText_sourcepath = wx.StaticText(
-            self,
+            self.leftPanel,
             wx.ID_ANY,
             "Folder of the library to import:",
             wx.DefaultPosition,
@@ -143,7 +159,7 @@ class impartGUI(wx.Dialog):
         bSizer.Add(self.m_staticText_sourcepath, 0, wx.ALL, 5)
 
         self.m_dirPicker_sourcepath = wx.DirPickerCtrl(
-            self,
+            self.leftPanel,
             wx.ID_ANY,
             ".",
             "Select a folder",
@@ -153,10 +169,10 @@ class impartGUI(wx.Dialog):
         )
         bSizer.Add(self.m_dirPicker_sourcepath, 0, wx.ALL | wx.EXPAND, 5)
 
-        bSizer2 = wx.BoxSizer(wx.HORIZONTAL)
+        bSizer2 = wx.WrapSizer(wx.HORIZONTAL)
 
         self.m_staticText_librarypath = wx.StaticText(
-            self,
+            self.leftPanel,
             wx.ID_ANY,
             "Library save location:",
             wx.DefaultPosition,
@@ -165,22 +181,22 @@ class impartGUI(wx.Dialog):
         )
         self.m_staticText_librarypath.Wrap(-1)
 
-        bSizer2.Add(self.m_staticText_librarypath, 0, wx.ALL, 5)
+        bSizer2.Add(self.m_staticText_librarypath, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
 
         self.m_checkBoxLocalLib = wx.CheckBox(
-            self,
+            self.leftPanel,
             wx.ID_ANY,
             "Save local, in the project folder",
             wx.DefaultPosition,
             wx.DefaultSize,
             0,
         )
-        bSizer2.Add(self.m_checkBoxLocalLib, 0, wx.ALL, 5)
+        bSizer2.Add(self.m_checkBoxLocalLib, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
 
-        bSizer.Add(bSizer2, 0, 0, 5)
+        bSizer.Add(bSizer2, 0, wx.EXPAND, 0)
 
         self.m_dirPicker_librarypath = wx.DirPickerCtrl(
-            self,
+            self.leftPanel,
             wx.ID_ANY,
             ".",
             "Select a folder",
@@ -191,7 +207,7 @@ class impartGUI(wx.Dialog):
         bSizer.Add(self.m_dirPicker_librarypath, 0, wx.ALL | wx.EXPAND, 5)
 
         self.m_staticline1 = wx.StaticLine(
-            self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL
+            self.leftPanel, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL
         )
         self.m_staticline1.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW))
         self.m_staticline1.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
@@ -199,23 +215,8 @@ class impartGUI(wx.Dialog):
 
         bSizer.Add(self.m_staticline1, 0, wx.EXPAND | wx.ALL, 5)
 
-        self.m_staticText5 = wx.StaticText(
-            self,
-            wx.ID_ANY,
-            "There is no guarantee for faultless function. Use only at your own risk. Should there be any errors please write an issue.\nNecessary settings for the integration of the libraries can be found in the README:",
-            wx.DefaultPosition,
-            wx.DefaultSize,
-            0,
-        )
-        self.m_staticText5.Wrap(-1)
-
-        self.m_staticText5.Hide()
-        self.m_staticText5.SetMinSize(wx.Size(-1, 50))
-
-        bSizer.Add(self.m_staticText5, 0, wx.EXPAND | wx.TOP | wx.RIGHT | wx.LEFT, 5)
-
         self.m_hyperlink = wx.adv.HyperlinkCtrl(
-            self,
+            self.leftPanel,
             wx.ID_ANY,
             "github.com/Steffen-W/Import-LIB-KiCad-Plugin",
             "https://github.com/Steffen-W/Import-LIB-KiCad-Plugin",
@@ -225,7 +226,18 @@ class impartGUI(wx.Dialog):
         )
         bSizer.Add(self.m_hyperlink, 0, wx.BOTTOM | wx.RIGHT | wx.LEFT, 5)
 
-        self.SetSizer(bSizer)
+        self.leftPanel.SetSizer(bSizer)
+
+        # ----------------- Right Panel (Component Search) -----------------
+        self.rightPanel = wx.Panel(self.splitter)
+        self.rightSizer = wx.BoxSizer(wx.VERTICAL)
+        self.rightPanel.SetSizer(self.rightSizer)
+
+        # Split left and right panels with a draggable sash (default position at 520px)
+        self.splitter.SplitVertically(self.leftPanel, self.rightPanel, sashPosition=520)
+
+        dialogSizer.Add(self.splitter, 1, wx.EXPAND | wx.ALL, 4)
+        self.SetSizer(dialogSizer)
         self.Layout()
 
         self.Centre(wx.BOTH)
@@ -235,7 +247,7 @@ class impartGUI(wx.Dialog):
         self.m_button.Bind(wx.EVT_BUTTON, self.BottonClick)
         self.m_buttonImportManual.Bind(wx.EVT_BUTTON, self.ButtomManualImport)
         self.m_textCtrl2.Bind(wx.EVT_TEXT_ENTER, self.ButtomManualImport)
-        self.m_buttonComponentSearch.Bind(wx.EVT_BUTTON, self.OnComponentSearch)
+        self.m_buttonToggleSearch.Bind(wx.EVT_BUTTON, self.OnToggleSearchPanel)
         self.m_dirPicker_sourcepath.Bind(wx.EVT_DIRPICKER_CHANGED, self.DirChange)
         self.m_checkBoxLocalLib.Bind(wx.EVT_CHECKBOX, self.m_checkBoxLocalLibOnCheckBox)
         self.m_checkBoxSingleLib.Bind(wx.EVT_CHECKBOX, self.m_checkBoxSingleLibOnCheckBox)
@@ -254,7 +266,7 @@ class impartGUI(wx.Dialog):
     def ButtomManualImport(self, event):
         event.Skip()
 
-    def OnComponentSearch(self, event):
+    def OnToggleSearchPanel(self, event):
         event.Skip()
 
     def DirChange(self, event):


### PR DESCRIPTION
### Summary of Changes

This PR delivers major UI/UX improvements to the plugin, focusing on seamless component search, multi-project library management, and better responsive controls.

---

#### 1. Collapsible Component Search & 1-Click Import
- **Embedded Search Panel:** Integrated the JLCPCB / EasyEDA search panel into the main dialog via a draggable `wx.SplitterWindow`.
- **Toggle Button (`🔍 Search ▶ / ◀`):** Added an on-demand button to expand or collapse the search panel.
- **Preference Persistence:** Stored search panel visibility in `config.ini` (default: collapsed, preserving original compact layout).
- **1-Click & Double-Click Import:** Added an **"📥 Import to KiCad"** button and double-click / Enter activation on search results to trigger instant EasyEDA import with live status logging.

#### 2. Smart Library Auto-Discovery & Selector Button (`📚 (X)`)
- **Dynamic Discovery:** Automatically scans the active target location (`${KIPRJMOD}` in local mode or `${KICAD_3RD_PARTY}` in global mode) for existing `*.kicad_sym` and `*.pretty` libraries.
- **Count Badge & Dropdown Menu:** Displays the count of found libraries (e.g. `📚 (2)`). Clicking opens a popup menu allowing instant selection of existing libraries or setting the current project's name.
- **Smart Project Defaults:** Solves the issue where stale library names from previous projects persisted when switching projects. Empty local projects now default to the active KiCad project name.

#### 3. Responsive Layout & Comprehensive Tooltips
- **Responsive Wrapping (`wx.WrapSizer`):** Options, checkboxes, and search controls now wrap cleanly without getting clipped when resizing panels.
- **Grouped Single Lib Controls:** Grouped `single lib name` checkbox, text field, and picker button into a single unit so they wrap together.
- **Tooltips:** Added descriptive tooltips across all checkboxes, folder pickers, and action buttons.

---

### Verification
- Tested with KiCad 10 (Linux Flatpak & standalone wxPython).
- Verified single-lib discovery across local project and global directories.
- Automated tests passed for config persistence, splitter toggles, and library scanning.